### PR TITLE
Implement native Home Assistant Ingress authentication

### DIFF
--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -224,6 +224,16 @@ Allows you to specify a default ingress user if desired (e.g. `admin`).
 
 If no ingress user is set, the default login authentication is used.
 
+### Option: `ha_user`
+
+Allows you to use native home assistant login through ingress.
+
+Set to `true` to enable this, `false` otherwise.
+
+When `true`,
+ The current user accessing ingress is forwarded to grocy.  
+ `grocy_ingress_user` option is ignored
+
 ### Option: `printers`
 
 Configures label and thermal printer support.

--- a/grocy/config.yaml
+++ b/grocy/config.yaml
@@ -49,6 +49,7 @@ options:
   ssl: true
   certfile: fullchain.pem
   keyfile: privkey.pem
+  ha_user: true
   grocy_ingress_user: ""
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
@@ -92,4 +93,5 @@ schema:
   ssl: bool
   certfile: str
   keyfile: str
+  ha_user: bool
   grocy_ingress_user: str

--- a/grocy/config.yaml
+++ b/grocy/config.yaml
@@ -49,7 +49,7 @@ options:
   ssl: true
   certfile: fullchain.pem
   keyfile: privkey.pem
-  ha_user: true
+  ha_user: false
   grocy_ingress_user: ""
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?

--- a/grocy/rootfs/etc/nginx/templates/direct.gtpl
+++ b/grocy/rootfs/etc/nginx/templates/direct.gtpl
@@ -19,6 +19,7 @@ server {
         fastcgi_read_timeout 900;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_index index.php;
+        fastcgi_param HTTP_REMOTE_USER "";
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include /etc/nginx/includes/fastcgi_params.conf;
     }

--- a/grocy/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/grocy/rootfs/etc/nginx/templates/ingress.gtpl
@@ -12,10 +12,14 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_index index.php;
 
-        {{ if .grocy_user }}
+        {{ if or .ha_user .grocy_user }}
         fastcgi_param GROCY_AUTH_CLASS "Grocy\Middleware\Auth\ReverseProxyAuthMiddleware";
         fastcgi_param GROCY_REVERSE_PROXY_AUTH_HEADER REMOTE_USER;
+        {{ if .ha_user }}
+        fastcgi_param HTTP_REMOTE_USER $http_x_remote_user_name;
+        {{ else if .grocy_user }}
         fastcgi_param HTTP_REMOTE_USER {{ .grocy_user }};
+        {{ end }}
         {{ end }}
 
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -9,6 +9,7 @@
 bashio::var.json \
     interface "$(bashio::app.ip_address)" \
     grocy_user "$(bashio::config 'grocy_ingress_user')" \
+    ha_user "$(bashio::config 'ha_user')" \
     | tempio \
         -template /etc/nginx/templates/ingress.gtpl \
         -out /etc/nginx/servers/ingress.conf

--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -9,7 +9,7 @@
 bashio::var.json \
     interface "$(bashio::app.ip_address)" \
     grocy_user "$(bashio::config 'grocy_ingress_user')" \
-    ha_user "$(bashio::config 'ha_user')" \
+    ha_user "^$(bashio::config 'ha_user')" \
     | tempio \
         -template /etc/nginx/templates/ingress.gtpl \
         -out /etc/nginx/servers/ingress.conf


### PR DESCRIPTION
# Proposed Changes

Introduce seamless, native ingress authentication within Grocy via a new configuration option: enable_ingress_auth. When enabled, users are automatically provisioned and logged into Grocy with their active home assistant login via their HA session headers. 

Additionally, users are authenticated through HA's supervisor when logging in directly from grocy.

## Related Issues

No related issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to enable native Home Assistant login through ingress, disabled by default.
  * When enabled, the current Home Assistant ingress user is forwarded to Grocy for authentication.
  * Added configuration support for enabling or disabling this login method.
  * When disabled, direct access does not provide a remote user for authentication.

* **Documentation**
  * Documented the new login option and clarified that the configured Grocy ingress user is ignored when native Home Assistant login is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->